### PR TITLE
UX Enhancements and Mode-Specific Progress Tracking

### DIFF
--- a/components/SendingMode/SendingMode.tsx
+++ b/components/SendingMode/SendingMode.tsx
@@ -573,16 +573,15 @@ const SendingMode: React.FC = () => {
     keyerRef.current = keyer;
   }, [keyer]);
   
-  // Start test
-  const handleStartTest = useCallback(() => {
-    
+  // Clean restart with time recording 
+  const startTestAndRecordTime = useCallback(() => {
     // Reset all state
     setCurrentChar('');
     setMorseOutput('');
     setFeedbackState('none');
     setIncorrectChar('');
     setStrikeCount(0);
-    strikeCountRef.current = 0; // Reset strike count ref
+    strikeCountRef.current = 0;
     setResponseTimes([]);
     setMistakesMap({});
     setTestResults(null);
@@ -596,26 +595,19 @@ const SendingMode: React.FC = () => {
     // Make sure the keyer is installed and listening for key events
     keyerRef.current.install();
     
-    // Always set the test start time when starting a test - both ref and state
+    // Set test start time
     const now = Date.now();
     testStartTimeRef.current = now;
     setTestStartTime(now);
     
-    // Start the test in the AppState
+    // Start the test in the AppState using the current selected level
     startTest();
     
-    // Need a slight delay to ensure state is updated
+    // Start the first question after a short delay
     setTimeout(() => {
       nextQuestion();
-    }, 100);
-  }, [startTest, nextQuestion, isCheckpoint, strikeLimit]);
-  
-  // Clean restart with time recording (now handleStartTest already sets the time)
-  // TODO: Remove this? I think it is redundant
-  const startTestAndRecordTime = useCallback(() => {
-    console.log('[SendingMode] If you see this you need to cleanup. Starting test with time recording');
-    handleStartTest();
-  }, [handleStartTest]);
+    }, 150);
+  }, [nextQuestion, startTest]);
   
   // Handle moving to specific level
   // TODO: combine the various ways to start a test
@@ -815,6 +807,13 @@ const SendingMode: React.FC = () => {
     currentCharRef: currentCharRef.current,
     morseOutput
   };
+  
+  // Clear test results when level changes
+  useEffect(() => {
+    if (testResults) {
+      setTestResults(null);
+    }
+  }, [state.selectedLevelId]);
   
   return (
     <div className={styles.sendingTrainer}>

--- a/components/SendingMode/SendingMode.tsx
+++ b/components/SendingMode/SendingMode.tsx
@@ -730,6 +730,9 @@ const SendingMode: React.FC = () => {
       // Move to next level
       const nextLevel = trainingLevels[currentLevelIndex + 1];
       
+      // Explicitly select the next level to update both state and UI
+      selectLevel(nextLevel.id);
+      
       // Set the test start time
       setTestStartTime(Date.now());
       
@@ -739,7 +742,7 @@ const SendingMode: React.FC = () => {
       // Restart current level if at end
       startTestAndRecordTime();
     }
-  }, [state.selectedLevelId, startTestWithExplicitLevel, startTestAndRecordTime]);
+  }, [state.selectedLevelId, startTestWithExplicitLevel, startTestAndRecordTime, selectLevel]);
   
   // Calculate progress - mastered characters using local points
   // Use levelCharsRef for consistent mastery calculations

--- a/components/TestResultsSummary/TestResultsSummary.tsx
+++ b/components/TestResultsSummary/TestResultsSummary.tsx
@@ -45,7 +45,7 @@ const TestResultsSummary: React.FC<TestResultsSummaryProps> = ({
   onNext
 }) => {
   const { user, refreshXpInfo, updateXp } = useAuth();
-  const { state, getCurrentLevel } = useAppState();
+  const { state, getCurrentLevel, isLevelCompleted } = useAppState();
   const [historyAvgTimes, setHistoryAvgTimes] = useState<Record<string, number>>({});
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
@@ -177,7 +177,7 @@ const TestResultsSummary: React.FC<TestResultsSummaryProps> = ({
           const currentLevel = getCurrentLevel();
           levelCompletionXp = { total: 0, breakdown: {} };
           
-          if (completed && currentLevel && !state.completedLevels.includes(levelId)) {
+          if (completed && currentLevel && !isLevelCompleted(levelId)) {
             levelCompletionXp = calculateLevelCompletionXp(
               levelId, 
               currentLevel.type === 'checkpoint'
@@ -272,7 +272,7 @@ const TestResultsSummary: React.FC<TestResultsSummaryProps> = ({
     saveResults();
     
     // Only depend on completed state and user to minimize re-runs
-  }, [completed, user, levelId, responseTimes, mistakesMap, state.mode, state.completedLevels, getCurrentLevel, elapsedTime, replayCount, refreshXpInfo, updateXp]);
+  }, [completed, user, levelId, responseTimes, mistakesMap, state.mode, isLevelCompleted, getCurrentLevel, elapsedTime, replayCount, refreshXpInfo, updateXp]);
   // Format time as MM:SS with hover tooltip for precise seconds
   const formatTime = (totalSec: number) => {
     const minutes = Math.floor(totalSec / 60);

--- a/components/TopMenu/TopMenu.module.css
+++ b/components/TopMenu/TopMenu.module.css
@@ -248,5 +248,12 @@
 
 .themeButton.activeTheme {
   background-color: var(--accent-color, #00e676);
-  color: var(--primary-bg, #1f1f1f);
+}
+
+/* Icon styling for consistent icon sizes */
+.menuIcon {
+  font-size: 1.7rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 } 

--- a/components/TopMenu/TopMenu.module.css
+++ b/components/TopMenu/TopMenu.module.css
@@ -243,5 +243,8 @@
 
 /* Icon styling for consistent icon sizes */
 .menuIcon {
-  font-size: 1.7rem;
+  font-size: 1.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 } 

--- a/components/TopMenu/TopMenu.module.css
+++ b/components/TopMenu/TopMenu.module.css
@@ -105,20 +105,11 @@
 }
 
 .menuItem.active {
-  color: var(--accent-color, #00e676);
+  color: var(--accent-color);
 }
 
-/* Special styling for race menu item */
-.menuItem[data-mode="race"],
-.raceMenuItem {
-  position: relative;
-  color: inherit; /* Reset color */
-  text-decoration: none; /* Remove underline */
-}
-
-.menuItem[data-mode="race"].active,
-.raceMenuItem.active {
-  color: var(--accent-color, #00e676); /* Use accent color from globals.css */
+.menuItem.active:hover {
+  color: var(--text-color, #e0e0e0);
 }
 
 .menuItem input[type="radio"] {
@@ -253,7 +244,4 @@
 /* Icon styling for consistent icon sizes */
 .menuIcon {
   font-size: 1.7rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
 } 

--- a/components/TopMenu/TopMenu.tsx
+++ b/components/TopMenu/TopMenu.tsx
@@ -38,12 +38,38 @@ const TopMenu: React.FC = () => {
     setMounted(true);
   }, []);
   
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleModeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setMode(event.target.value as 'copy' | 'send');
+  // Handle mode change with proper navigation
+  const handleModeChange = () => {
+    // Toggle between copy and send mode
+    const newMode = state.mode === 'copy' ? 'send' : 'copy';
+    
+    // End any active test
+    if (state.testActive) {
+      endTest(false);
+    }
+    
+    // Set the new mode
+    setMode(newMode);
+    
+    // Ensure we're in training mode
+    if (state.testType !== 'training') {
+      setTestType('training');
+      router.push('/');
+    }
   };
   
   const handleTestTypeClick = (testType: TestType) => {
+    // End any active test
+    if (state.testActive) {
+      endTest(false);
+    }
+    
+    // Force test reset when clicking on "training"
+    // This ensures we go back to the start screen even from test results
+    if (testType === 'training') {
+      endTest(false);
+    }
+    
     setTestType(testType);
     
     // Handle navigation based on test type
@@ -52,6 +78,8 @@ const TopMenu: React.FC = () => {
     } else if (testType === 'zen') {
       router.push('/zen');
     } else if (testType === 'training') {
+      // When returning to training, just navigate to home
+      // We'll keep the current level and mode
       router.push('/');
     } else if (testType === 'time') {
       router.push('/time');
@@ -66,8 +94,18 @@ const TopMenu: React.FC = () => {
       endTest(false);
     }
     
+    // Force the test to reset to the start screen by ending it
+    // This ensures level selection works even when on the test results screen
+    endTest(false);
+    
     selectLevel(id);
     setShowLevels(false);
+    
+    // Ensure we're in training mode and route to the home page
+    if (state.testType !== 'training') {
+      setTestType('training');
+      router.push('/');
+    }
   };
   
   const handleSpeedChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -110,7 +148,7 @@ const TopMenu: React.FC = () => {
         <div className={styles.menuSection}>
           <div 
             className={styles.toggleTrack} 
-            onClick={() => setMode(state.mode === 'copy' ? 'send' : 'copy')}
+            onClick={handleModeChange}
           >
             <span className={`${styles.toggleLabel} ${state.mode === 'copy' ? styles.activeLabel : ''}`}>copy</span>
             <span className={`${styles.toggleLabel} ${state.mode === 'send' ? styles.activeLabel : ''}`}>send</span>
@@ -270,4 +308,4 @@ const TopMenu: React.FC = () => {
   );
 };
 
-export default TopMenu; 
+export default TopMenu;

--- a/components/TopMenu/TopMenu.tsx
+++ b/components/TopMenu/TopMenu.tsx
@@ -114,8 +114,8 @@ const TopMenu: React.FC = () => {
       // When returning to training, just navigate to home
       // We'll keep the current level and mode
       router.push('/');
-    } else if (testType === 'time') {
-      router.push('/time');
+    } else if (testType === 'pota') {
+      router.push('/pota');
     } else if (testType === 'words') {
       router.push('/words');
     }
@@ -197,28 +197,6 @@ const TopMenu: React.FC = () => {
         {/* Middle section - Test Types */}
         <div className={styles.menuSection}>
           <button 
-            className={`${styles.menuItem} ${state.testType === 'time' ? styles.active : ''}`}
-            onClick={() => handleTestTypeClick('time')}
-            disabled={true} // Feature not yet implemented
-            title="Coming soon! Complete as many characters as possible in a set amount of time."
-          >
-            time
-          </button>
-          <button 
-            className={`${styles.menuItem} ${state.testType === 'zen' ? styles.active : ''}`}
-            onClick={() => handleTestTypeClick('zen')}
-          >
-            zen
-          </button>
-          <button 
-            className={`${styles.menuItem} ${state.testType === 'words' ? styles.active : ''}`}
-            onClick={() => handleTestTypeClick('words')}
-            disabled={true} // Feature not yet implemented
-            title="Coming soon! Identify or send words of various sizes."
-          >
-            words
-          </button>
-          <button 
             className={`${styles.menuItem} ${state.testType === 'training' ? styles.active : ''}`}
             onClick={() => handleTestTypeClick('training')}
           >
@@ -230,6 +208,28 @@ const TopMenu: React.FC = () => {
             data-mode="race"
           >
             race
+          </button>
+          <button 
+            className={`${styles.menuItem} ${state.testType === 'zen' ? styles.active : ''}`}
+            onClick={() => handleTestTypeClick('zen')}
+          >
+            zen
+          </button>
+          <button 
+            className={`${styles.menuItem} ${state.testType === 'pota' ? styles.active : ''}`}
+            onClick={() => handleTestTypeClick('pota')}
+            disabled={true} // Feature not yet implemented
+            title="Coming soon! Get familiar with a POTA exchange. Practice hunting and activating."
+          >
+            pota
+          </button>
+          <button 
+            className={`${styles.menuItem} ${state.testType === 'words' ? styles.active : ''}`}
+            onClick={() => handleTestTypeClick('words')}
+            disabled={true} // Feature not yet implemented
+            title="Coming soon! Identify or send words of various sizes."
+          >
+            words
           </button>
         </div>
         

--- a/components/TopMenu/TopMenu.tsx
+++ b/components/TopMenu/TopMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useAppState } from '../../contexts/AppStateContext';
 import { trainingLevels } from '../../utils/levels';
 import ProgressDashboard from '../ProgressDashboard/ProgressDashboard';
@@ -33,10 +33,43 @@ const TopMenu: React.FC = () => {
   const [showProgress, setShowProgress] = useState(false);
   const [mounted, setMounted] = useState(false);
   
+  // Refs for dropdown containers
+  const levelDropdownRef = useRef<HTMLDivElement>(null);
+  const settingsDropdownRef = useRef<HTMLDivElement>(null);
+  
   // Only run client-side code after mount
   useEffect(() => {
     setMounted(true);
   }, []);
+  
+  // Handle clicks outside dropdown menus
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      // Close level dropdown if click is outside
+      if (showLevels && 
+          levelDropdownRef.current && 
+          !levelDropdownRef.current.contains(event.target as Node)) {
+        setShowLevels(false);
+      }
+      
+      // Close settings dropdown if click is outside
+      if (showSettings && 
+          settingsDropdownRef.current && 
+          !settingsDropdownRef.current.contains(event.target as Node)) {
+        setShowSettings(false);
+      }
+    };
+    
+    // Add event listener when dropdowns are open
+    if (showLevels || showSettings) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    
+    // Clean up event listener
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showLevels, showSettings]);
   
   // Handle mode change with proper navigation
   const handleModeChange = () => {
@@ -203,7 +236,7 @@ const TopMenu: React.FC = () => {
         {/* Right section - Levels and Settings */}
         <div className={styles.menuSection}>
           {/* Level selector */}
-          <div className={styles.levelSelector}>
+          <div className={styles.levelSelector} ref={levelDropdownRef}>
             <button 
               className={`${styles.menuItem} ${styles.active}`} 
               onClick={() => setShowLevels(!showLevels)}
@@ -227,84 +260,86 @@ const TopMenu: React.FC = () => {
           </div>
           
           {/* Settings gear icon */}
-          <button 
-            className={styles.menuItem}
-            onClick={() => setShowSettings(!showSettings)}
-          >
-            ⚙
-          </button>
-          
-          {showSettings && (
-            <ul className={styles.settingsDropdown}>
-              <li>
-                <label>
-                  Speed: <span>{state.wpm}</span> WPM
-                  <input 
-                    type="range" 
-                    min="5" 
-                    max="40" 
-                    step="1" 
-                    value={state.wpm} 
-                    onChange={handleSpeedChange} 
-                  />
-                </label>
-              </li>
-              <li>
-                <label>
-                  Volume: <span>{state.volume}</span>%
-                  <input 
-                    type="range" 
-                    min="0" 
-                    max="100" 
-                    step="1" 
-                    value={state.volume} 
-                    onChange={handleVolumeChange} 
-                  />
-                </label>
-              </li>
-              <li>
-                <label>
-                  Send Speed: <span>{state.sendWpm}</span> WPM
-                  <input 
-                    type="range" 
-                    min="5" 
-                    max="40" 
-                    step="1" 
-                    value={state.sendWpm} 
-                    onChange={handleSendSpeedChange} 
-                  />
-                </label>
-              </li>
-              <li>
-                <label>Theme:</label>
-                <div className={styles.themeOptions}>
+          <div ref={settingsDropdownRef}>
+            <button 
+              className={styles.menuItem}
+              onClick={() => setShowSettings(!showSettings)}
+            >
+              <span className={styles.menuIcon}>⚙</span>
+            </button>
+            
+            {showSettings && (
+              <ul className={styles.settingsDropdown}>
+                <li>
+                  <label>
+                    Speed: <span>{state.wpm}</span> WPM
+                    <input 
+                      type="range" 
+                      min="5" 
+                      max="40" 
+                      step="1" 
+                      value={state.wpm} 
+                      onChange={handleSpeedChange} 
+                    />
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    Volume: <span>{state.volume}</span>%
+                    <input 
+                      type="range" 
+                      min="0" 
+                      max="100" 
+                      step="1" 
+                      value={state.volume} 
+                      onChange={handleVolumeChange} 
+                    />
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    Send Speed: <span>{state.sendWpm}</span> WPM
+                    <input 
+                      type="range" 
+                      min="5" 
+                      max="40" 
+                      step="1" 
+                      value={state.sendWpm} 
+                      onChange={handleSendSpeedChange} 
+                    />
+                  </label>
+                </li>
+                <li>
+                  <label>Theme:</label>
+                  <div className={styles.themeOptions}>
+                    <button 
+                      className={`${styles.themeButton} ${state.theme === 'default' ? styles.activeTheme : ''}`}
+                      onClick={() => handleThemeChange('default')}
+                    >
+                      default
+                    </button>
+                    <button 
+                      className={`${styles.themeButton} ${state.theme === 'catppuccin-mocha' ? styles.activeTheme : ''}`}
+                      onClick={() => handleThemeChange('catppuccin-mocha')}
+                    >
+                      catppuccin 
+                    </button>
+                  </div>
+                </li>
+                <li>
                   <button 
-                    className={`${styles.themeButton} ${state.theme === 'default' ? styles.activeTheme : ''}`}
-                    onClick={() => handleThemeChange('default')}
+                    className={styles.settingsItem}
+                    onClick={() => {
+                      setShowSettings(false);
+                      setShowProgress(true);
+                    }}
                   >
-                    default
+                    My Progress
                   </button>
-                  <button 
-                    className={`${styles.themeButton} ${state.theme === 'catppuccin-mocha' ? styles.activeTheme : ''}`}
-                    onClick={() => handleThemeChange('catppuccin-mocha')}
-                  >
-                    catppuccin 
-                  </button>
-                </div>
-              </li>
-              <li>
-                <button 
-                  className={styles.settingsItem}
-                  onClick={() => {
-                    setShowSettings(false);
-                    setShowProgress(true);
-                  }}
-                >
-                  My Progress
-                </button>
-              </li>
-            </ul>
-          )}
+                </li>
+              </ul>
+            )}
+          </div>
         </div>
       </div>
     </nav>

--- a/components/TopMenu/TopMenu.tsx
+++ b/components/TopMenu/TopMenu.tsx
@@ -21,7 +21,8 @@ const TopMenu: React.FC = () => {
     setVolume, 
     setSendWpm,
     setTheme,
-    endTest
+    endTest,
+    isLevelCompleted
   } = useAppState();
   
   const router = useRouter();
@@ -249,7 +250,7 @@ const TopMenu: React.FC = () => {
                 {trainingLevels.map(level => (
                   <li 
                     key={level.id}
-                    className={`${styles.levelItem} ${state.completedLevels.includes(level.id) ? styles.completed : ''} ${state.selectedLevelId === level.id ? styles.selected : ''}`}
+                    className={`${styles.levelItem} ${isLevelCompleted(level.id) ? styles.completed : ''} ${state.selectedLevelId === level.id ? styles.selected : ''}`}
                     onClick={() => handleLevelClick(level.id)}
                   >
                     {level.name}

--- a/components/TopMenu/TopMenu.tsx
+++ b/components/TopMenu/TopMenu.tsx
@@ -98,14 +98,19 @@ const TopMenu: React.FC = () => {
     // This ensures level selection works even when on the test results screen
     endTest(false);
     
+    // Select the level
     selectLevel(id);
     setShowLevels(false);
     
-    // Ensure we're in training mode and route to the home page
-    if (state.testType !== 'training') {
+    // Only navigate to training mode if we're not in race mode
+    if (state.testType !== 'training' && state.testType !== 'race') {
       setTestType('training');
       router.push('/');
+    } else if (state.testType === 'training') {
+      // If already in training mode, ensure we're on the home page
+      router.push('/');
     }
+    // If in race mode, do nothing - just stay on the race page with the new level selected
   };
   
   const handleSpeedChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/components/TrainingMode/TrainingMode.tsx
+++ b/components/TrainingMode/TrainingMode.tsx
@@ -488,6 +488,10 @@ const TrainingMode: React.FC = () => {
             
             if (currentLevelIndex >= 0 && currentLevelIndex < trainingLevels.length - 1) {
               const nextLevel = trainingLevels[currentLevelIndex + 1];
+              
+              // Explicitly select the next level to update both state and UI
+              selectLevel(nextLevel.id);
+              
               setTestStartTime(Date.now());
               startTestWithLevelId(nextLevel.id);
               

--- a/components/TrainingMode/TrainingMode.tsx
+++ b/components/TrainingMode/TrainingMode.tsx
@@ -417,6 +417,13 @@ const TrainingMode: React.FC = () => {
     }
   }, [checkLevelChars]);
   
+  // Clear test results when level changes
+  useEffect(() => {
+    if (testResults) {
+      setTestResults(null);
+    }
+  }, [state.selectedLevelId]);
+  
   return (
     <div className={styles.trainingContainer}>
       {/* Debug state information - only visible on client in development */}

--- a/contexts/AppStateContext.tsx
+++ b/contexts/AppStateContext.tsx
@@ -13,7 +13,7 @@ interface CharTiming {
 }
 
 type Mode = 'copy' | 'send' | 'race';
- type TestType = 'training' | 'time' | 'words' | 'race' | 'zen';
+type TestType = 'training' | 'time' | 'words' | 'race' | 'zen' | 'pota';
 type Theme = 'default' | 'catppuccin-mocha';
 
 export interface AppState {

--- a/contexts/AppStateContext.tsx
+++ b/contexts/AppStateContext.tsx
@@ -194,6 +194,18 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
       // Save to localStorage
       if (typeof window !== 'undefined') {
         localStorage.setItem('morseCompleted', JSON.stringify(newCompletedLevels));
+        
+        // Automatically advance the next level in localStorage ONLY
+        // This way when the user refreshes, they'll be at the next level
+        // but we don't immediately advance the UI
+        const currentLevelIndex = trainingLevels.findIndex(level => level.id === id);
+        if (currentLevelIndex >= 0 && currentLevelIndex < trainingLevels.length - 1) {
+          // Get the next level ID
+          const nextLevelId = trainingLevels[currentLevelIndex + 1].id;
+          
+          // Update localStorage only, without changing the current UI state
+          localStorage.setItem('morseSelectedLevel', nextLevelId);
+        }
       }
     }
   };

--- a/contexts/AppStateContext.tsx
+++ b/contexts/AppStateContext.tsx
@@ -16,13 +16,27 @@ type Mode = 'copy' | 'send' | 'race';
 type TestType = 'training' | 'time' | 'words' | 'race' | 'zen' | 'pota';
 type Theme = 'default' | 'catppuccin-mocha';
 
+// Track completed levels by mode
+export interface CompletedLevels {
+  copy: string[];
+  send: string[];
+}
+
+// Track selected level by mode
+export interface SelectedLevels {
+  copy: string;
+  send: string; 
+}
+
 export interface AppState {
-  // Current selected level
+  // Current selected level for each mode
+  selectedLevels: SelectedLevels;
+  // Current selected level ID - used for the active mode
   selectedLevelId: string;
   // Character mastery points
   charPoints: CharPoints;
-  // Completed levels
-  completedLevels: string[];
+  // Completed levels by mode
+  completedLevels: CompletedLevels;
   // User settings
   wpm: number;
   volume: number;
@@ -45,6 +59,7 @@ interface AppStateContextType {
   selectLevel: (id: string) => void;
   getCurrentLevel: () => TrainingLevel | undefined;
   markLevelCompleted: (id: string) => void;
+  isLevelCompleted: (id: string) => boolean;
   
   // Test management
   startTest: () => void;
@@ -78,8 +93,15 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
     // Set default values
     const initialState: AppState = {
       selectedLevelId: '',
+      selectedLevels: {
+        copy: '',
+        send: ''
+      },
       charPoints: {},
-      completedLevels: [],
+      completedLevels: {
+        copy: [],
+        send: []
+      },
       wpm: 20,
       volume: 75,
       sendWpm: 20,
@@ -118,18 +140,60 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
       
       // Load completed levels from localStorage
       try {
-        const completedString = localStorage.getItem('morseCompleted');
-        if (completedString) {
-          initialState.completedLevels = JSON.parse(completedString);
+        // First try to load the new format (mode-specific completed levels)
+        const copyCompletedString = localStorage.getItem('morseCompletedCopy');
+        const sendCompletedString = localStorage.getItem('morseCompletedSend');
+        
+        if (copyCompletedString) {
+          initialState.completedLevels.copy = JSON.parse(copyCompletedString);
+        }
+        
+        if (sendCompletedString) {
+          initialState.completedLevels.send = JSON.parse(sendCompletedString);
+        }
+        
+        // Migrate from old format if needed
+        if (!copyCompletedString && !sendCompletedString) {
+          const legacyCompletedString = localStorage.getItem('morseCompleted');
+          if (legacyCompletedString) {
+            const legacyCompleted = JSON.parse(legacyCompletedString);
+            // Assume all legacy completed levels are in copy mode
+            initialState.completedLevels.copy = legacyCompleted;
+            
+            // Save in the new format for future use
+            localStorage.setItem('morseCompletedCopy', legacyCompletedString);
+          }
         }
       } catch (error) {
         console.error('Error loading completed levels from localStorage:', error);
       }
       
-      // Load selected level from localStorage
-      const storedSelectedLevelId = localStorage.getItem('morseSelectedLevel');
-      if (storedSelectedLevelId) {
-        initialState.selectedLevelId = storedSelectedLevelId;
+      // Load selected levels from localStorage - new format
+      try {
+        const copySelectedLevelId = localStorage.getItem('morseSelectedLevelCopy');
+        const sendSelectedLevelId = localStorage.getItem('morseSelectedLevelSend');
+        
+        if (copySelectedLevelId) {
+          initialState.selectedLevels.copy = copySelectedLevelId;
+        }
+        
+        if (sendSelectedLevelId) {
+          initialState.selectedLevels.send = sendSelectedLevelId;
+        }
+        
+        // Migration from old format for backward compatibility
+        if (!copySelectedLevelId && !sendSelectedLevelId) {
+          const legacySelectedLevelId = localStorage.getItem('morseSelectedLevel');
+          if (legacySelectedLevelId) {
+            // Store it in both modes for migration, but prioritize copy mode
+            initialState.selectedLevels.copy = legacySelectedLevelId;
+            
+            // Save in the new format for future use
+            localStorage.setItem('morseSelectedLevelCopy', legacySelectedLevelId);
+          }
+        }
+      } catch (error) {
+        console.error('Error loading selected levels from localStorage:', error);
       }
       
       // Load mode from localStorage
@@ -139,10 +203,21 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
       }
     }
     
-    // If no selected level is stored in localStorage, determine the initial selected level
-    if (!initialState.selectedLevelId && trainingLevels.length > 0) {
+    // Calculate initial selectedLevelId based on current mode
+    const currentMode = initialState.mode === 'race' ? 'copy' : initialState.mode;
+    const currentSelectedLevelId = initialState.selectedLevels[currentMode];
+    
+    // If we have a saved level for the current mode, use it
+    if (currentSelectedLevelId) {
+      initialState.selectedLevelId = currentSelectedLevelId;
+    } 
+    // Otherwise find the first incomplete level for current mode
+    else if (trainingLevels.length > 0) {
+      // Get completed levels for the current mode
+      const currentModeCompletedLevels = initialState.completedLevels[currentMode];
+      
       const firstIncomplete = trainingLevels.find(
-        level => !initialState.completedLevels.includes(level.id)
+        level => !currentModeCompletedLevels.includes(level.id)
       );
       
       const selectedLevel = firstIncomplete 
@@ -150,6 +225,7 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
         : trainingLevels[trainingLevels.length - 1];
         
       initialState.selectedLevelId = selectedLevel.id;
+      initialState.selectedLevels[currentMode] = selectedLevel.id;
     }
     
     // Set the character set to match the selected level
@@ -163,19 +239,32 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
   
   // Level management functions
   const selectLevel = (id: string) => {
+    // Determine which mode's selected level to update
+    const modeToUpdate = state.mode === 'race' ? 'copy' : state.mode;
+    
     // Find the level to get its characters
     const level = trainingLevels.find(level => level.id === id);
     const levelChars = level ? [...level.chars] : [...defaultChars];
     
-    setState(prev => ({
-      ...prev,
-      selectedLevelId: id,
-      chars: levelChars,
-    }));
+    setState(prev => {
+      // Create updated selectedLevels
+      const updatedSelectedLevels = {
+        ...prev.selectedLevels,
+        [modeToUpdate]: id
+      };
+      
+      return {
+        ...prev,
+        selectedLevelId: id,
+        selectedLevels: updatedSelectedLevels,
+        chars: levelChars,
+      };
+    });
     
-    // Store selected level in localStorage
+    // Store selected level in localStorage - both in legacy and new format
     if (typeof window !== 'undefined') {
-      localStorage.setItem('morseSelectedLevel', id);
+      localStorage.setItem('morseSelectedLevel', id); // Legacy format
+      localStorage.setItem(`morseSelectedLevel${modeToUpdate.charAt(0).toUpperCase() + modeToUpdate.slice(1)}`, id); // New format
     }
   };
   
@@ -183,9 +272,24 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
     return trainingLevels.find(level => level.id === state.selectedLevelId);
   };
   
+  // Check if a level is completed in the current mode
+  const isLevelCompleted = (id: string) => {
+    // Use 'copy' mode for race since they share the same completed levels
+    const modeToCheck = state.mode === 'race' ? 'copy' : state.mode;
+    return state.completedLevels[modeToCheck].includes(id);
+  };
+  
   const markLevelCompleted = (id: string) => {
-    if (!state.completedLevels.includes(id)) {
-      const newCompletedLevels = [...state.completedLevels, id];
+    // Use 'copy' mode for race since they share the same completed levels
+    const modeToUpdate = state.mode === 'race' ? 'copy' : state.mode;
+    
+    if (!state.completedLevels[modeToUpdate].includes(id)) {
+      // Create a new completed levels object
+      const newCompletedLevels = {
+        ...state.completedLevels,
+        [modeToUpdate]: [...state.completedLevels[modeToUpdate], id]
+      };
+      
       setState(prev => ({
         ...prev,
         completedLevels: newCompletedLevels,
@@ -193,7 +297,8 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
       
       // Save to localStorage
       if (typeof window !== 'undefined') {
-        localStorage.setItem('morseCompleted', JSON.stringify(newCompletedLevels));
+        localStorage.setItem(`morseCompleted${modeToUpdate.charAt(0).toUpperCase() + modeToUpdate.slice(1)}`, 
+          JSON.stringify(newCompletedLevels[modeToUpdate]));
         
         // Automatically advance the next level in localStorage ONLY
         // This way when the user refreshes, they'll be at the next level
@@ -312,12 +417,26 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
   
   // Mode and test type
   const setMode = (mode: Mode) => {
+    // Get the selected level for the target mode (or race → copy)
+    const targetMode = mode === 'race' ? 'copy' : mode;
+    const targetLevelId = state.selectedLevels[targetMode] || state.selectedLevelId;
+    
     setState(prev => ({
       ...prev,
       mode,
+      selectedLevelId: targetLevelId,
       // End test when changing modes to ensure we return to start screen
       testActive: false
     }));
+    
+    // Update the current level's characters
+    const targetLevel = trainingLevels.find(level => level.id === targetLevelId);
+    if (targetLevel) {
+      setState(prev => ({
+        ...prev,
+        chars: [...targetLevel.chars]
+      }));
+    }
     
     // Store mode in localStorage
     if (typeof window !== 'undefined') {
@@ -400,6 +519,7 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
       selectLevel,
       getCurrentLevel,
       markLevelCompleted,
+      isLevelCompleted,
       startTest,
       startTestWithLevelId,
       endTest,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Layout from '../components/Layout/Layout';
 import TrainingMode from '../components/TrainingMode/TrainingMode';
 import SendingMode from '../components/SendingMode/SendingMode';
@@ -7,6 +7,12 @@ import { useAppState } from '../contexts/AppStateContext';
 
 export default function Home() {
   const { state } = useAppState();
+  const [isClient, setIsClient] = useState(false);
+  
+  // Only render mode-specific components after hydration is complete
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   const renderActiveMode = () => {
     // Race mode - check test type first
@@ -23,11 +29,18 @@ export default function Home() {
     if (state.mode === 'send') {
       return <SendingMode />;
     }
+    
+    // Default fallback - this should rarely happen
+    return null;
   };
 
   return (
     <Layout>
-      {renderActiveMode()}
+      {isClient ? renderActiveMode() : 
+        <div style={{ minHeight: '300px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <div>Loading...</div>
+        </div>
+      }
     </Layout>
   );
 } 


### PR DESCRIPTION

# UX Enhancements and Mode-Specific Progress Tracking

This PR introduces significant improvements to the user experience and adds mode-specific progress tracking to properly handle copy and send modes separately.

## Major Changes

### Mode-Specific Progress Tracking
- **Split completedLevels by mode**: Now tracking completed levels separately for copy and send modes
- **Split selectedLevel by mode**: Each mode remembers its own last selected level
- **Automatic migration**: Existing user data will be automatically migrated to the new format
- **Proper race mode handling**: Race mode shares completion and level state with copy mode

### Navigation & UI Improvements
- **Fixed race mode level selection**: Selecting a level in race mode now stays in race mode instead of redirecting to training
- **Click-outside behavior**: Dropdowns (level selector and settings) now close when clicking outside
- **Consistent icon styling**: Added a CSS class for menu icons to ensure consistent sizing
- **Reordered top nav**: Changed order to training, race, zen, pota, words for better usability
- **Fixed hover behavior**: Restored consistent hover effects on menu items, even when active

### Technical Improvements
- **Type safety**: Added 'pota' to TestType definitions to fix TypeScript errors
- **Helper functions**: Added `isLevelCompleted()` to check completion status by mode
- **localStorage management**: Updated to use mode-specific keys for storing progress

## Migration Notes
- Users' existing completion data will be migrated to copy mode
- Legacy `morseCompleted` localStorage will be migrated to `morseCompletedCopy`
- All progress for both copy and send modes is preserved separately

## Testing
- Verified that switching between modes preserves mode-specific progress
- Confirmed that level completion is tracked separately in each mode
- Ensured backwards compatibility with existing user data
